### PR TITLE
feature: introduce infrastructure context

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 
 	Ctl "globe-and-citizen/layer8/server/resource_server/controller"
 	"globe-and-citizen/layer8/server/resource_server/dto"
@@ -42,7 +43,7 @@ func getPwd() {
 }
 
 func main() {
-	ctx, cancel := signal.NotifyContext(context.Background())
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	// Use flags to set the port


### PR DESCRIPTION
**Description**
when i started the service i wasn't able to shutdown using cmd+c .
i want do introduce infra context which blocks until system is sending sigint or sigterm.
also docker will send the signal to gracefully shutdown the service.